### PR TITLE
add github pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,0 +1,1 @@
+## Submitting an Issue

--- a/.github/ISSUE_TEMPLATE/bugs_template.md
+++ b/.github/ISSUE_TEMPLATE/bugs_template.md
@@ -1,0 +1,29 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+
+---
+
+## *What* version has the bug?
+<!-- Ex. v1beta.123 -->
+
+
+## *What* is affected by this bug?
+<!-- Ex. Agent Server  -->
+
+
+## *When* does this occur?
+<!-- Be specific as possible -->
+
+
+## *How* do we replicate the issue?
+<!-- Please be specific as possible. Use dashes (-) or numbers (1.) to create a list of steps -->
+
+
+## Expected behavior (i.e. solution)
+<!-- What should have happened? -->
+
+
+## Other Comments
+<!-- Attach relevant sanitized logs. Important: sanitze any sensitive info from any logs attached! -->
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F680 Feature request"
+about: Suggest an idea/feature for this project
+
+---
+
+<!--
+Thank you for suggesting an idea/feature request.
+
+Please fill in as much of the template below as you're able.
+-->
+
+**Is your feature request related to a problem? Please describe.**
+Please describe the problem you are trying to solve.
+
+**Describe the solution you'd like**
+Please describe the desired behavior.
+
+**Describe alternatives you've considered**
+Please describe alternative solutions or features you have considered.

--- a/.github/ISSUE_TEMPLATE/help_template.md
+++ b/.github/ISSUE_TEMPLATE/help_template.md
@@ -1,0 +1,7 @@
+---
+name: "⁉️ Need help?"
+about: Please file an issue in our help repo.
+
+---
+
+We would love to help! Please ensure that you have searched thru the available documentation, done some additional research on the problem, and if all else fails, please let us know how we can help!

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+* **Please check if the PR fulfills these requirements**
+- [ ] The commit message follows our guidelines (see contribution docs for details)
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+- [ ] Link/Ref to open Issue is included in the PR
+
+
+* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+
+
+
+* **What is the current behavior?** (You can link to an open issue here)
+
+
+
+* **What is the new behavior (if this is a feature change)?**
+
+
+
+* **Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
+
+
+
+* **Other information**:


### PR DESCRIPTION
Addresses Issue #64 

This PR adds default Issue and PR templates for this repo. This PR is being issued against the default branch of the repo, but these changes will most likely need to be added to other branches that will be the base of merges (templates will need to exist in the base of a PR for PR templates). I am not 100% on this, but I think this is how it still works for github templates.