### PR TITLE
revert pxy flag change

### DIFF
--- a/spec/agent/client.yml
+++ b/spec/agent/client.yml
@@ -14,5 +14,6 @@ ec-config:
     cps: {EC_CPS}
     hca: "{EC_HCA}"
     lpt: "{EC_LPT}"
+    pxy: "{EC_PXY}"
     #fup: agent_solaris_sparc64_sys:ayasuda_copy_example_2
     #fdw: ayasuda_copy_example_2:anotherfile_example

--- a/spec/agent/client.yml
+++ b/spec/agent/client.yml
@@ -14,6 +14,5 @@ ec-config:
     cps: {EC_CPS}
     hca: "{EC_HCA}"
     lpt: "{EC_LPT}"
-    pxy: {EC_PXY}
     #fup: agent_solaris_sparc64_sys:ayasuda_copy_example_2
     #fdw: ayasuda_copy_example_2:anotherfile_example


### PR DESCRIPTION
Reverting the pxy flag for following reasons - 
- If no value defined in env vars, assigning boolean value 'false' in k8 and agent throwing error. So either agent should ignore pxy flag when it has boolean value or should be deleted when no value in env vars
- pxy flag is needed only when running from corp network. 